### PR TITLE
Add datasets_drug_design.md with initial dataset list

### DIFF
--- a/drug_design/datasets_drug_design.md
+++ b/drug_design/datasets_drug_design.md
@@ -8,6 +8,6 @@ This document lists datasets relevant to AI-assisted immunotherapy development a
 | SDAP | [SDAP](http://fermi.utmb.edu/SDAP/) | Protein/allergen structures & epitopes | Key allergy-specific dataset | Open |
 | AllergenOnline | [allergenonline.org](http://www.allergenonline.org/) | Protein allergen sequences | Useful for allergen cross-reactivity analysis | Open |
 | Immune Epitope Database (IEDB) | [iedb.org](https://www.iedb.org) | Epitope & immunogenicity | Supports AI in immunotherapy design | Open |
-| lamm-mit/protein_secondary_structure_from_PDB | Hugging Face | Protein Sequences | Protein Sequences | 125,955 sequences with secondary structure annotations (α-helix, β-sheet); useful for AI models predicting protein folding and designing hypoallergenic proteins; format: Parquet | Open   |
+| Protein Structures Dataset from PDB | [Hugging Face] (https://huggingface.co/datasets/lamm-mit/protein_secondary_structure_from_PDB) | Protein Sequences | 125,955 sequences with secondary structure annotations (α-helix, β-sheet); useful for AI models predicting protein folding and designing hypoallergenic proteins; format: Parquet | Open   |
 
 

--- a/drug_design/datasets_drug_design.md
+++ b/drug_design/datasets_drug_design.md
@@ -8,3 +8,6 @@ This document lists datasets relevant to AI-assisted immunotherapy development a
 | SDAP | [SDAP](http://fermi.utmb.edu/SDAP/) | Protein/allergen structures & epitopes | Key allergy-specific dataset | Open |
 | AllergenOnline | [allergenonline.org](http://www.allergenonline.org/) | Protein allergen sequences | Useful for allergen cross-reactivity analysis | Open |
 | Immune Epitope Database (IEDB) | [iedb.org](https://www.iedb.org) | Epitope & immunogenicity | Supports AI in immunotherapy design | Open |
+| lamm-mit/protein_secondary_structure_from_PDB | Hugging Face | Protein Sequences | Protein Sequences | 125,955 sequences with secondary structure annotations (α-helix, β-sheet); useful for AI models predicting protein folding and designing hypoallergenic proteins; format: Parquet | Open   |
+
+

--- a/drug_design/datasets_drug_design.md
+++ b/drug_design/datasets_drug_design.md
@@ -1,0 +1,10 @@
+# Drug Design Datasets for Food Allergy Research
+
+This document lists datasets relevant to AI-assisted immunotherapy development and allergen protein structure analysis.
+
+| Dataset | Source | Type | Notes | Access |
+|---------|--------|------|-------|--------|
+| Protein Data Bank (PDB) | [rcsb.org](https://www.rcsb.org) | Protein 3D structures | Structural modeling for allergenic proteins | Open |
+| SDAP | [SDAP](http://fermi.utmb.edu/SDAP/) | Protein/allergen structures & epitopes | Key allergy-specific dataset | Open |
+| AllergenOnline | [allergenonline.org](http://www.allergenonline.org/) | Protein allergen sequences | Useful for allergen cross-reactivity analysis | Open |
+| Immune Epitope Database (IEDB) | [iedb.org](https://www.iedb.org) | Epitope & immunogenicity | Supports AI in immunotherapy design | Open |


### PR DESCRIPTION
Added a Markdown file listing datasets relevant to AI-assisted immunotherapy and allergen protein analysis. Includes PDB, SDAP, IEDB, AllergenOnline
